### PR TITLE
Add dockerignore file to prevent unwanted files in build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+README.md


### PR DESCRIPTION
Adding a dockerignore file to prevent git repo or docs from being baked into the image.
