### PR TITLE
Fix render_cfg status code check. Remove tmp files on error in render_cfg

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,9 +50,10 @@ fi
 while sleep $UPDATE_FREQUENCY; do
 	/render_cfg.sh $SERVICE_HOSTNAME $TEMPLATE
 	# Exit code 0 means template was updated, 1 means error and 2 means not updated
-	if [ $? -eq 0 ]; then
+    RENDER_RESULT=$?
+	if [ $RENDER_RESULT -eq 0 ]; then
         reload
-	elif [ $? -eq 1 ]; then
+	elif [ $RENDER_RESULT -eq 1 ]; then
 		echo "Error updating config template"
 	fi
 done &

--- a/render_cfg.sh
+++ b/render_cfg.sh
@@ -13,16 +13,19 @@ nslookup $service 2>/dev/null | gawk '/Address /{print $3}' | sort | paste -sd '
 
 # Check for fatal errors
 if ! [ -f $template ]; then
+  rm $tmpfile
   echo "Template file $template does not exist."
   exit 1
 fi
 if [ $(wc -c $tmpfile | gawk '{print $1}') -eq 0 ]; then
+  rm $tmpfile
   echo "Unable to resolve addresses for $service "
   exit 1
 fi
 
 # Check if IP addresses for service changed
 if test -f $oldfile && cmp -s $oldfile $tmpfile; then
+  rm $tmpfile
   exit 2
 fi
 

--- a/render_cfg.sh
+++ b/render_cfg.sh
@@ -29,6 +29,11 @@ if test -f $oldfile && cmp -s $oldfile $tmpfile; then
   exit 2
 fi
 
+# Remove oldfile to prevent tmp file accumulation
+if [ -f $oldfile ]; then
+  rm $oldfile
+fi
+
 prefix=node
 IFS=',' read -ra ips < $tmpfile
 tmptpl=$(mktemp -t tpl.XXXXXXX)


### PR DESCRIPTION
Saves RENDER_RESULT from /render_cfg check in entrypoint to avoid `test` from returning status codes checked further down the chain.

Removes tmp files in render_cfg on `exit` calls.